### PR TITLE
Added git attributes enforcing CRLF on checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,57 @@
+* text=auto
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+
+# Normalise endings to CRLF
+*.cs              eol=crlf
+*.xml             eol=crlf
+*.xaml            eol=crlf
+*.xsl             eol=crlf
+*.xsd             eol=crlf
+*.cshtml          eol=crlf
+*.css             eol=crlf
+*.js              eol=crlf
+*.txt             eol=crlf
+*.config          eol=crlf
+*.sql             eol=crlf
+*.sln             eol=crlf
+*.csproj          eol=crlf
+*.vbproj          eol=crlf
+*.fsproj          eol=crlf
+*.dbproj          eol=crlf
+*.nunit           eol=crlf
+*.html            eol=crlf
+*.md              eol=crlf
+*.proj            eol=crlf
+*.bat             eol=crlf
+*.cmd             eol=crlf
+*.nuspec          eol=crlf
+*.targets         eol=crlf
+*.conf            eol=crlf
+*.manifest        eol=crlf
+*.ps1             eol=crlf
+*.resx            eol=crlf
+*.asax            eol=crlf
+*.aspx            eol=crlf
+*.ncrunchproject  eol=crlf
+*.ncrunchsolution eol=crlf
+*.msbuild         eol=crlf
+*.template        eol=crlf
+*.settings        eol=crlf
+*.java            eol=crlf
+.gitattributes    eol=crlf
+.classpath        eol=crlf
+.project          eol=crlf
+
+# Standard to msysgit
+*.doc  diff=astextplain
+*.DOC  diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF  diff=astextplain
+*.rtf  diff=astextplain
+*.RTF  diff=astextplain


### PR DESCRIPTION
I cloned the repository on Mac, where Git defaults line endings to LF. That made PowerShell interpret the scripts as one-liners starting with a comment, thereby doing absolutely nothing. This commit forces CRLF for most files on checkout (they are preserved as LF in the git blob) through `.gitattributes`.

After merging this, you might want to do delete `.git/index` and do a `get reset --hard` to do a clean checkout with correct line endings. Shouldn't matter on Windows, but shouldn't hurt either. :)