### PR TITLE
Fixed issues #18, #19, and #20

### DIFF
--- a/Get-FileEncoding.ps1
+++ b/Get-FileEncoding.ps1
@@ -1,0 +1,85 @@
+﻿##############################################################################
+##
+## Get-FileEncoding
+##
+## From Windows PowerShell Cookbook (O'Reilly)
+## by Lee Holmes (http://www.leeholmes.com/guide)
+##
+##############################################################################
+function Get-FileEncoding {     
+    <#
+     
+    .SYNOPSIS
+     
+    Gets the encoding of a file
+     
+    .EXAMPLE
+     
+    Get-FileEncoding.ps1 .\UnicodeScript.ps1
+     
+    BodyName          : unicodeFFFE
+    EncodingName      : Unicode (Big-Endian)
+    HeaderName        : unicodeFFFE
+    WebName           : unicodeFFFE
+    WindowsCodePage   : 1200
+    IsBrowserDisplay  : False
+    IsBrowserSave     : False
+    IsMailNewsDisplay : False
+    IsMailNewsSave    : False
+    IsSingleByte      : False
+    EncoderFallback   : System.Text.EncoderReplacementFallback
+    DecoderFallback   : System.Text.DecoderReplacementFallback
+    IsReadOnly        : True
+    CodePage          : 1201
+     
+    #>
+    [CmdletBinding()]
+    param(
+        ## The path of the file to get the encoding of.
+        $Path
+    )
+     
+    Set-StrictMode -Version Latest
+     
+    ## The hashtable used to store our mapping of encoding bytes to their
+    ## name. For example, "255-254 = Unicode"
+    $encodings = @{}
+     
+    ## Find all of the encodings understood by the .NET Framework. For each,
+    ## determine the bytes at the start of the file (the preamble) that the .NET
+    ## Framework uses to identify that encoding.
+    $encodingMembers = [System.Text.Encoding] |
+        Get-Member -Static -MemberType Property
+     
+    $encodingMembers | Foreach-Object {
+        $encodingBytes = [System.Text.Encoding]::($_.Name).GetPreamble() -join '-'
+        $encodings[$encodingBytes] = $_.Name
+    }
+     
+    ## Find out the lengths of all of the preambles.
+    $encodingLengths = $encodings.Keys | Where-Object { $_ } |
+        Foreach-Object { ($_ -split "-").Count }
+     
+    ## Assume the encoding is UTF7 by default
+    $result = "UTF7"
+     
+    ## Go through each of the possible preamble lengths, read that many
+    ## bytes from the file, and then see if it matches one of the encodings
+    ## we know about.
+    foreach($encodingLength in $encodingLengths | Sort -Descending)
+    {
+        $bytes = (Get-Content -encoding byte -readcount $encodingLength $path)[0]
+        $encoding = $encodings[$bytes -join '-']
+     
+        ## If we found an encoding that had the same preamble bytes,
+        ## save that output and break.
+        if($encoding)
+        {
+            $result = $encoding
+            break
+        }
+    }
+     
+    ## Finally, output the encoding.
+    Return [System.Text.Encoding]::$result
+}

--- a/migrateToAutomaticPackageRestore.ps1
+++ b/migrateToAutomaticPackageRestore.ps1
@@ -1,3 +1,5 @@
+. (Join-Path $PSScriptRoot "Get-FileEncoding.ps1")
+
 ########################################
 # Regex Patterns for Really Bad Things!
 $listOfBadStuff = @(
@@ -7,6 +9,7 @@ $listOfBadStuff = @(
 	"\s*<Import Project=""\$\(SolutionDir\)\\\.nuget\\NuGet\.targets"".*?/>",
 	"\s*<Target Name=""EnsureNuGetPackageBuildImports"" BeforeTargets=""PrepareForBuild"">(.|\n)*?</Target>"
 	"\s*<RestorePackages>\w*</RestorePackages>"
+    "\s*<SolutionDir Condition=""\$\(SolutionDir\) == '' Or \$\(SolutionDir\) == '\*Undefined\*'"">\.\.\\</SolutionDir>"
 )
 
 #######################
@@ -19,7 +22,7 @@ ls -Recurse -include 'NuGet.exe','NuGet.targets' |
 }
 
 #########################################################################################
-# Fix Project and Solution Files to reverse damage done by "Enable NuGet Package Restore
+# Fix Project and Solution Files to reverse damage done by "Enable NuGet Package Restore"
 
 ls -Recurse -include *.csproj, *.sln, *.fsproj, *.vbproj, *.wixproj, *.vcxproj |
   foreach {
@@ -29,8 +32,10 @@ ls -Recurse -include *.csproj, *.sln, *.fsproj, *.vbproj, *.wixproj, *.vcxproj |
         $content = $content -replace $badStuff, ""
     }
     if ($origContent -ne $content)
-    {	
-        $content | out-file -encoding "UTF8" $_.FullName
+    {
+        $encoding = Get-FileEncoding $_.FullName
+
+        [System.IO.File]::WriteAllText($_.FullName, $content, $encoding)
         write-host messed with $_.Name
     }		    
 }


### PR DESCRIPTION
#18: Avoiding inserting blank lines at the end of project files by using [System.IO.File]::WriteAllText instead of out-file
#19: Removed <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
#20: Using the same file encoding when saving the file