### PR TITLE
Turn off read-only flag before trying to modify file

### DIFF
--- a/migrateToAutomaticPackageRestore.ps1
+++ b/migrateToAutomaticPackageRestore.ps1
@@ -23,6 +23,7 @@ ls -Recurse -include 'NuGet.exe','NuGet.targets' |
 
 ls -Recurse -include *.csproj, *.sln, *.fsproj, *.vbproj, *.wixproj, *.vcxproj |
   foreach {
+    ps $_ IsReadOnly $false
     $content = cat $_.FullName | Out-String
     $origContent = $content
     foreach($badStuff in $listOfBadStuff){


### PR DESCRIPTION
This fix turns off the read-only attribute (TFS!!) so the project files can be modified.