### PR TITLE
Add missing comma after 3rd array item

### DIFF
--- a/migrateToAutomaticPackageRestore.ps1
+++ b/migrateToAutomaticPackageRestore.ps1
@@ -5,7 +5,7 @@ $listOfBadStuff = @(
 	"\s*(\.nuget\\NuGet\.(exe|targets)) = \1",
 	#*proj regexes
 	"\s*<Import Project=""\$\(SolutionDir\)\\\.nuget\\NuGet\.targets"".*?/>",
-	"\s*<Target Name=""EnsureNuGetPackageBuildImports"" BeforeTargets=""PrepareForBuild"">(.|\n)*?</Target>"
+	"\s*<Target Name=""EnsureNuGetPackageBuildImports"" BeforeTargets=""PrepareForBuild"">(.|\n)*?</Target>",
 	"\s*<RestorePackages>\w*</RestorePackages>"
 )
 


### PR DESCRIPTION
This PR adds a missing comma after the 3rd item in the `$listOfBadStuff` array of `migrateToAutomaticPackageRestore.ps1`.